### PR TITLE
pointed the shortened link to the original link

### DIFF
--- a/app.css
+++ b/app.css
@@ -458,8 +458,15 @@ button:hover {
      text-overflow: ellipsis;
 }
 .main__cutter-shortened-links p:nth-child(3) {
-    color: var(--cyan);
     margin: 0 20px 0 10%;
+}
+.main__cutter-shortened-links p:nth-child(3) a {
+    color: var(--cyan);
+    text-decoration: none;
+}
+.main__cutter-shortened-links p:nth-child(3) a:hover {
+    color: var(--cyan);
+    text-decoration: underline;
 }
 .main__cutter-shortened-links button {
     height: 30px;

--- a/app.css
+++ b/app.css
@@ -465,7 +465,6 @@ button:hover {
     text-decoration: none;
 }
 .main__cutter-shortened-links p:nth-child(3) a:hover {
-    color: var(--cyan);
     text-decoration: underline;
 }
 .main__cutter-shortened-links button {

--- a/app.js
+++ b/app.js
@@ -129,7 +129,7 @@ function createShortenedLink(originalLink, shortenedLink){
         `
           <p id="original-link">${originalLink}</p>
           <hr />
-          <p><a target="_blank" href="${originalLink}" id="shortened-link">${shortenedLink}</a></p>
+          <p><a href="${originalLink}" target="_blank" id="shortened-link">${shortenedLink}</a></p>
           <button class="main__cutter-shortened-btn copy-btn">Copy</button>
         `
     ;

--- a/app.js
+++ b/app.js
@@ -129,7 +129,7 @@ function createShortenedLink(originalLink, shortenedLink){
         `
           <p id="original-link">${originalLink}</p>
           <hr />
-          <p><a href="${originalLink}" id="shortened-link">${shortenedLink}</a></p>
+          <p><a target="_blank" href="${originalLink}" id="shortened-link">${shortenedLink}</a></p>
           <button class="main__cutter-shortened-btn copy-btn">Copy</button>
         `
     ;

--- a/app.js
+++ b/app.js
@@ -129,7 +129,7 @@ function createShortenedLink(originalLink, shortenedLink){
         `
           <p id="original-link">${originalLink}</p>
           <hr />
-          <p id="shortened-link">${shortenedLink}</p>
+          <p><a href="${originalLink}" id="shortened-link">${shortenedLink}</a></p>
           <button class="main__cutter-shortened-btn copy-btn">Copy</button>
         `
     ;


### PR DESCRIPTION
The shortened link initially couldn't be clicked. I made the shortened URL point to the main URL so that users can test the shortened link without leaving the page.